### PR TITLE
fix: no hover effect in drag (#56)

### DIFF
--- a/examples/example04-draggable.html
+++ b/examples/example04-draggable.html
@@ -1,85 +1,86 @@
 <!DOCTYPE html>
 <html>
-    <head lang="en">
-        <meta charset="UTF-8">
-        <title>Tree with "Draggable" feature</title>
-        <link rel="stylesheet" type="text/css" href="./css/tui-example-style.css" />
-        <link rel="stylesheet" type="text/css" href="./css/docs.css" />
-        <link rel="stylesheet" type="text/css" href="../dist/tui-tree.css" />
-    </head>
+  <head lang="en">
+    <meta charset="UTF-8" />
+    <title>Tree with "Draggable" feature</title>
+    <link rel="stylesheet" type="text/css" href="./css/tui-example-style.css" />
+    <link rel="stylesheet" type="text/css" href="./css/docs.css" />
+    <link rel="stylesheet" type="text/css" href="../dist/tui-tree.css" />
+  </head>
 
-    <body>
-        <div class="code-html">
-            <div id="tree" class="tui-tree-wrap"></div>
-        </div>
-        <div class="explain">
-            <textarea id="movedValue" readonly></textarea>
-        </div>
-        <script src="../dist/tui-tree.js"></script>
-        <script class="code-js">
+  <body>
+    <div class="code-html">
+      <div id="tree" class="tui-tree-wrap"></div>
+    </div>
+    <div class="explain">
+      <textarea id="movedValue" readonly></textarea>
+    </div>
+    <script src="../dist/tui-tree.js"></script>
+    <script class="code-js">
+      var util = {
+        addEventListener: function(element, eventName, handler) {
+          if (element.addEventListener) {
+            element.addEventListener(eventName, handler, false);
+          } else {
+            element.attachEvent('on' + eventName, handler);
+          }
+        }
+      };
 
-        var util = {
-            addEventListener: function(element, eventName, handler) {
-                if (element.addEventListener) {
-                    element.addEventListener(eventName, handler, false);
-                } else {
-                    element.attachEvent('on' + eventName, handler);
-                }
-            }
-        };
+      var data = [
+        {
+          text: 'rootA',
+          children: [
+            { text: 'sub-A1' },
+            { text: 'sub-A2' },
+            { text: 'sub-A3' },
+            { text: 'sub-A4' },
+            {
+              text: 'sub-A5',
+              state: 'closed',
+              children: [{ text: 'sub-A5A', children: [{ text: 'sub-A5A1' }] }, { text: 'sub_A5B' }]
+            },
+            { text: 'sub-A6' },
+            { text: 'sub-A7' },
+            { text: 'sub-A8' },
+            {
+              text: 'sub-A9',
+              state: 'closed',
+              children: [{ text: 'sub-A9A' }, { text: 'sub-A9B' }]
+            },
+            { text: 'sub-A10' },
+            { text: 'sub-A11' },
+            { text: 'sub-A12' }
+          ]
+        },
+        {
+          text: 'rootB',
+          state: 'closed',
+          children: [{ text: 'sub-B1' }, { text: 'sub-B2' }, { text: 'sub-B3' }]
+        }
+      ];
 
-        var data = [
-            {text: 'rootA', children: [
-                {text: 'sub-A1'},
-                {text: 'sub-A2'},
-                {text: 'sub-A3'},
-                {text: 'sub-A4'},
-                {text: 'sub-A5', state: 'closed', children: [
-                    {text:'sub-A5A', children:[
-                        {text:'sub-A5A1'}
-                    ]},
-                    {text:'sub_A5B'}
-                ]},
-                {text: 'sub-A6'},
-                {text: 'sub-A7'},
-                {text: 'sub-A8'},
-                {text: 'sub-A9', state: 'closed', children: [
-                    {text:'sub-A9A'},
-                    {text:'sub-A9B'}
-                ]},
-                {text: 'sub-A10'},
-                {text: 'sub-A11'},
-                {text: 'sub-A12'}
-            ]},
-            {text: 'rootB', state:'closed', children: [
-                {text:'sub-B1'},
-                {text:'sub-B2'},
-                {text:'sub-B3'}
-            ]}
-        ];
+      var movedValue = document.getElementById('movedValue');
 
-        var movedValue = document.getElementById('movedValue');
+      var tree = new tui.Tree('#tree', {
+        data: data,
+        nodeDefaultState: 'opened'
+      }).enableFeature('Draggable', {
+        helperClassName: 'tui-tree-drop',
+        lineClassName: 'tui-tree-line',
+        isSortable: true
+      });
 
-        var tree = new tui.Tree('#tree', {
-            data: data,
-            nodeDefaultState: 'opened'
-        }).enableFeature('Draggable', {
-            helperClassName: 'tui-tree-drop',
-            lineClassName: 'tui-tree-line',
-            isSortable: true
-        });
+      tree.on('move', function(eventData) {
+        var msg;
 
-        tree.on('move', function(eventData) {
-            var msg;
+        msg = 'nodeId: ' + eventData.nodeId + '\n';
+        msg += 'originalParentId: ' + eventData.originalParentId + '\n';
+        msg += 'newParentId: ' + eventData.newParentId + '\n';
+        msg += 'index: ' + eventData.index + '\n';
 
-            msg = 'nodeId: ' + eventData.nodeId + '\n';
-            msg += 'originalParentId: ' + eventData.originalParentId + '\n';
-            msg += 'newParentId: ' + eventData.newParentId + '\n';
-            msg += 'index: ' + eventData.index + '\n';
-
-            movedValue.value = msg;
-        });
-
-        </script>
-    </body>
+        movedValue.value = msg;
+      });
+    </script>
+  </body>
 </html>

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -61,11 +61,11 @@ function setConfig(defaultConfig, server) {
       }
     };
     defaultConfig.browsers = [
-      'IE8',
+      // 'IE8',
       // 'IE9',
       'IE10',
       'IE11',
-      'Edge',
+      // 'Edge',
       'Chrome-WebDriver',
       'Firefox-WebDriver'
       // 'Safari-WebDriver'

--- a/src/css/tree.css
+++ b/src/css/tree.css
@@ -251,7 +251,8 @@
     content: '';
 }
 
-.tui-tree-content-wrapper:hover, .tui-tree-hover>.tui-tree-content-wrapper {
+.tui-tree-content-wrapper:hover,
+.tui-tree-hover > .tui-tree-content-wrapper {
     background: #e7eff7;
     background-color: rgba(75, 150, 230, .1);
 }

--- a/src/js/features/draggable.js
+++ b/src/js/features/draggable.js
@@ -641,7 +641,7 @@ var Draggable = defineClass(
      * @private
      */
     _isMovingLineElement: function(element) {
-      return hasClass(element, this.lineClassName);
+      return element && hasClass(element, this.lineClassName);
     }
   }
 );

--- a/src/js/features/draggable.js
+++ b/src/js/features/draggable.js
@@ -465,7 +465,7 @@ var Draggable = defineClass(
 
     /**
      * Apply move action that are delay effect and sortable moving node
-     * @param {strig} nodeId - Selected tree node id
+     * @param {string} nodeId - Selected tree node id
      * @param {object} mousePos - Current mouse position
      * @private
      */
@@ -535,22 +535,20 @@ var Draggable = defineClass(
     _isContain: function(targetPos, mousePos) {
       var top = targetPos.top;
       var bottom = targetPos.bottom;
+      var mousePosX = mousePos[0];
+      var mousePosY = mousePos[1];
 
       if (this.isSortable) {
         top += this.lineBoundary.top;
         bottom -= this.lineBoundary.bottom;
       }
 
-      if (
-        targetPos.left < mousePos.x &&
-        targetPos.right > mousePos.x &&
-        top < mousePos.y &&
-        bottom > mousePos.y
-      ) {
-        return true;
-      }
-
-      return false;
+      return (
+        targetPos.left < mousePosX &&
+        targetPos.right > mousePosX &&
+        top < mousePosY &&
+        bottom > mousePosY
+      );
     },
 
     /**

--- a/test/features/draggable.spec.js
+++ b/test/features/draggable.spec.js
@@ -61,8 +61,8 @@ describe('draggable feature', function() {
       currentElement = rootElement.querySelector('li');
       nodeId = tree.getNodeIdFromElement(currentElement);
       mousePos = {
-        x: 10,
-        y: 20
+        0: 10,
+        1: 20
       };
     });
 
@@ -131,8 +131,8 @@ describe('draggable feature', function() {
 
     it('should return true state when mouse position is in enable touched area', function() {
       mousePos = {
-        x: 10,
-        y: 20
+        0: 10,
+        1: 20
       };
 
       state = treeDraggable._isContain(targetPos, mousePos);
@@ -142,8 +142,8 @@ describe('draggable feature', function() {
 
     it('should return false state when mouse position is not in enable touched area', function() {
       mousePos = {
-        x: 2,
-        y: 3
+        0: 2,
+        1: 3
       };
 
       state = treeDraggable._isContain(targetPos, mousePos);


### PR DESCRIPTION
* Safari 브라우저에서 hover style이 먹히지 않는 버그를 수정했습니다! (#56)
  * `example04-draggable.html`, `tree.css`은 단순히 prettier 적용이라 스킵하셔도 됩니다
  * 원인은 mousePos의 0, 1 프로퍼티를 읽어야하는데 x, y 프로퍼티를 참조하여 발생한 버그였습니다.

* AS-IS
![화면-기록-2020-11-20-오후-12 01 17](https://user-images.githubusercontent.com/28647773/99752859-854c7a00-2b28-11eb-8f0b-2cf07603c268.gif)

* TO-BE
![화면-기록-2020-11-20-오후-12 03 17](https://user-images.githubusercontent.com/28647773/99752889-92696900-2b28-11eb-8fea-b76b514d0388.gif)
