### PR TITLE
fix: the select event fires after it is finished (fix #78)

### DIFF
--- a/src/js/features/selectable.js
+++ b/src/js/features/selectable.js
@@ -145,6 +145,7 @@ var Selectable = defineClass(
           removeClass(prevElement, selectedClassName);
         }
         addClass(nodeElement, selectedClassName);
+        this.selectedNodeId = nodeId;
 
         /**
          * @event Tree#select
@@ -166,7 +167,6 @@ var Selectable = defineClass(
           prevNodeId: prevNodeId,
           target: target
         });
-        this.selectedNodeId = nodeId;
       }
     },
 


### PR DESCRIPTION
## Describe the bug
`tree.deselect()` is not working in the `select` event.

## To Reproduce & Screenshots
```js
tree.on('select', function({nodeId}) {
  const nodeData = tree.getNodeData(nodeId);

  if (nodeData.disabled) {
    tree.deselect();
    return;
  }
            
  selectedValue.value = 'selected : ' + nodeData.text;
});
```

![tree-deselect](https://user-images.githubusercontent.com/8615506/108652246-03913180-7507-11eb-831b-8c606775cd1f.gif)

## Expected behavior
`tree.deselect()` works in the `select` event.
