### PR TITLE
fix: not add selected classname to child node

### DIFF
--- a/src/js/features/selectable.js
+++ b/src/js/features/selectable.js
@@ -112,8 +112,6 @@ var Selectable = defineClass(
       }
 
       tree = this.tree;
-      prevElement = this.getPrevElement();
-      nodeElement = document.getElementById(nodeId);
       selectedClassName = this.selectedClassName;
       prevNodeId = this.selectedNodeId;
 
@@ -139,6 +137,9 @@ var Selectable = defineClass(
         prevNodeId: prevNodeId,
         target: target
       });
+
+      prevElement = this.getPrevElement();
+      nodeElement = document.getElementById(nodeId);
 
       if (invokeResult) {
         if (prevElement) {

--- a/src/js/features/selectable.js
+++ b/src/js/features/selectable.js
@@ -105,13 +105,14 @@ var Selectable = defineClass(
      * @private
      */
     _select: function(nodeId, target) {
-      var tree, prevElement, nodeElement, selectedClassName, prevNodeId, invokeResult;
+      var tree, root, prevElement, nodeElement, selectedClassName, prevNodeId, invokeResult;
 
       if (!nodeId) {
         return;
       }
 
       tree = this.tree;
+      root = tree.rootElement;
       selectedClassName = this.selectedClassName;
       prevNodeId = this.selectedNodeId;
 
@@ -139,7 +140,7 @@ var Selectable = defineClass(
       });
 
       prevElement = this.getPrevElement();
-      nodeElement = document.getElementById(nodeId);
+      nodeElement = root.querySelector('#' + nodeId);
 
       if (invokeResult) {
         if (prevElement) {


### PR DESCRIPTION
* Modifications
  * When clicking on a parent node and clicking on a child node, the `tui-tree-selected` className was not added.
* Cause
It occurs when `setNodeData` API is called from `beforeSelect` event handler and is proceeding with the following flow.
  * Caching elements on clicked nodes
  * `beforeSelect` event occurred
  * Call `setNodeData` API
  * `update` event occurred
  * Call `_draw`
  * Modify `innerHTML` of the parent node of the clicked node <<<
  * Modify className of clicked node that was cached

In modifying the parent node `innerHTML` of the clicked node, the element reference of the previously cached clicked node becomes meaningless and does not add a proper className.

* Solution
Modify the caching point of the element so that className is added normally.

* AS-IS
  * ![화면-기록-2021-03-30-오후-5 39 21](https://user-images.githubusercontent.com/28647773/112961650-86e61880-9180-11eb-8796-0e33e2a09159.gif)
* TO-BE
  * ![화면-기록-2021-03-30-오후-5 40 38](https://user-images.githubusercontent.com/28647773/112961852-b6952080-9180-11eb-982f-0a5bdc2cb91b.gif)
