### PR TITLE
fix: errors in jsdoc comments, return type of isLeaf()

### DIFF
--- a/src/js/features/checkbox.js
+++ b/src/js/features/checkbox.js
@@ -553,7 +553,7 @@ var Checkbox = defineClass(
      * //    └─ node9 ( )
      *
      * var allCheckedList = tree.getCheckedList(); // ['node1', 'node2', 'node3' ,....]
-     * var descendantsCheckedList = tree.getCheekedList('node6'); // ['node7', 'node8']
+     * var descendantsCheckedList = tree.getCheckedList('node6'); // ['node7', 'node8']
      */
     getCheckedList: function(parentId) {
       var tree = this.tree;
@@ -585,7 +585,7 @@ var Checkbox = defineClass(
      * //    └─ node9 ( )
      *
      * var allTopCheckedList = tree.getTopCheckedList(); // ['node1', 'node5', 'node7']
-     * var descendantsTopCheckedList = tree.getTopCheekedList('node6'); // ['node7']
+     * var descendantsTopCheckedList = tree.getTopCheckedList('node6'); // ['node7']
      */
     getTopCheckedList: function(parentId) {
       var tree = this.tree;
@@ -617,7 +617,7 @@ var Checkbox = defineClass(
      * @returns {Array.<string>} Checked node ids
      * @example
      * var allBottomCheckedList = tree.getBottomCheckedList(); // ['node2', 'node3', 'node5', 'node8']
-     * var descendantsBottomCheckedList = tree.getBottomCheekedList('node6'); // ['node8']
+     * var descendantsBottomCheckedList = tree.getBottomCheckedList('node6'); // ['node8']
      */
     getBottomCheckedList: function(parentId) {
       var tree = this.tree;

--- a/src/js/features/draggable.js
+++ b/src/js/features/draggable.js
@@ -49,7 +49,6 @@ var API_LIST = [];
  *     @param {string} options.hoverClassName - Class name for hovered node
  *     @param {string} options.lineClassName - Class name for moving position line
  *     @param {string} options.helperClassName - Class name for helper's outer element
- *     @param {string} options.helperTemplate - Template string for helper's inner contents
  *     @param {{top: number, bottom: number}} options.lineBoundary - Boundary value for visible moving line
  * @ignore
  */

--- a/src/js/features/editable.js
+++ b/src/js/features/editable.js
@@ -25,10 +25,9 @@ var INPUT_CLASSNAME = 'tui-tree-input';
  * @class Editable
  * @param {Tree} tree - Tree
  * @param {Object} options - Options
- *  @param {string} options.editableClassName - Classname of editable element
+ *  @param {string} [options.editableClassName] - Classname of editable element
  *  @param {string} options.dataKey - Key of node data to set value
- *  @param {string} [options.dataValue] - Value of node data to set value (Use "createNode" API)
- *  @param {string} [options.inputClassName] - Classname of input element
+ *  @param {string} [options.defaultValue] - Default value to use when the user leaves the input empty
  * @ignore
  */
 var Editable = defineClass(

--- a/src/js/features/selectable.js
+++ b/src/js/features/selectable.js
@@ -115,7 +115,7 @@ var Selectable = defineClass(
        * @event Tree#beforeSelect
        * @type {object} evt - Event data
        * @property {string} nodeId - Selected node id
-       * @property {string} prevNodeId - Previous selected node id
+       * @property {?string} prevNodeId - Previous selected node id
        * @property {HTMLElement|undefined} target - Target element
        * @example
        * tree
@@ -148,7 +148,7 @@ var Selectable = defineClass(
          * @event Tree#select
          * @type {object} evt - Event data
          * @property {string} nodeId - Selected node id
-         * @property {string} prevNodeId - Previous selected node id
+         * @property {?string} prevNodeId - Previous selected node id
          * @property {HTMLElement|undefined} target - Target element
          * @example
          * tree
@@ -190,7 +190,7 @@ var Selectable = defineClass(
     /**
      * Get selected node id
      * @memberof Tree.prototype
-     * @returns {string} selected node id
+     * @returns {?string} selected node id
      */
     getSelectedNodeId: function() {
       return this.selectedNodeId;

--- a/src/js/tree.js
+++ b/src/js/tree.js
@@ -1409,7 +1409,7 @@ var Tree = defineClass(
      * - If 'isSilent' is not true, it redraws the tree
      * @param {string} nodeId - Node id
      * @param {string} newParentId - New parent id
-     * @param {number} index - Index number of selected node
+     * @param {number} [index] - Index number of selected node (default 0)
      * @param {object} [options] - Options
      *     @param {boolean} [options.isSilent] - If true, it doesn't trigger the 'update' event
      *     @param {boolean} [options.useAjax] - State of using Ajax
@@ -1454,7 +1454,7 @@ var Tree = defineClass(
      * - If 'isSilent' is not true, it redraws the tree
      * @param {string} nodeId - Node id
      * @param {string} newParentId - New parent id
-     * @param {number} index - Index number of selected node
+     * @param {number} [index] - Index number of selected node (default 0)
      * @param {boolean} [isSilent] - If true, it doesn't redraw children
      * @private
      */

--- a/src/js/tree.js
+++ b/src/js/tree.js
@@ -1569,7 +1569,7 @@ var Tree = defineClass(
     isLeaf: function(nodeId) {
       var node = this.model.getNode(nodeId);
 
-      return node && node.isLeaf();
+      return !!node && node.isLeaf();
     },
 
     /**

--- a/src/js/tree.js
+++ b/src/js/tree.js
@@ -858,7 +858,7 @@ var Tree = defineClass(
     /**
      * Get node data
      * @param {string} nodeId - Node id
-     * @returns {object|undefined} Node data
+     * @returns {?object} Node data
      */
     getNodeData: function(nodeId) {
       return this.model.getNodeData(nodeId);
@@ -873,7 +873,7 @@ var Tree = defineClass(
      *     @param {boolean} [options.useAjax] - State of using Ajax
      * @exmaple
      * tree.setNodeData(nodeId, {foo: 'bar'}); // auto refresh
-     * tree.setNodeData(nodeId, {foo: 'bar'}, true); // not refresh
+     * tree.setNodeData(nodeId, {foo: 'bar'}, {isSilent: true}); // not refresh
      */
     setNodeData: function(nodeId, data, options) {
       var treeAjax = this.enabledFeatures.Ajax;
@@ -916,8 +916,8 @@ var Tree = defineClass(
      *     @param {boolean} [options.isSilent] - If true, it doesn't trigger the 'update' event
      *     @param {boolean} [options.useAjax] - State of using Ajax
      * @example
-     * tree.setNodeData(nodeId, 'foo'); // auto refresh
-     * tree.setNodeData(nodeId, 'foo', true); // not refresh
+     * tree.removeNodeData(nodeId, 'foo'); // auto refresh
+     * tree.removeNodeData(nodeId, 'foo', {isSilent: true}); // not refresh
      */
     removeNodeData: function(nodeId, names, options) {
       var treeAjax = this.enabledFeatures.Ajax;
@@ -958,7 +958,7 @@ var Tree = defineClass(
      * @returns {string|null} Node state(('opened', 'closed', null)
      * @example
      * tree.getState(nodeId); // 'opened', 'closed',
-     *                        // undefined if the node is nonexistent
+     *                        // null if the node is nonexistent
      */
     getState: function(nodeId) {
       var node = this.model.getNode(nodeId);
@@ -1197,7 +1197,7 @@ var Tree = defineClass(
      * @param {object} [options] - Options
      *     @param {boolean} [options.isSilent] - If true, it doesn't redraw children
      *     @param {boolean} [options.useAjax] - State of using Ajax
-     * @returns {?Array.<string>} Added node ids
+     * @returns {Array.<string>|undefined} Added node ids
      * @example
      * // add node with redrawing
      * var firstAddedIds = tree.add({text:'FE development team1'}, parentId);
@@ -1207,7 +1207,9 @@ var Tree = defineClass(
      * var secondAddedIds = tree.add([
      *    {text: 'FE development team2'},
      *    {text: 'FE development team3'}
-     * ], parentId, true);
+     * ], parentId, {
+     *    isSilent: true
+     * });
      * console.log(secondAddedIds); // ["tui-tree-node-11", "tui-tree-node-12"]
      */
     add: function(data, parentId, options) {
@@ -1254,7 +1256,7 @@ var Tree = defineClass(
      * @param {object} [options] - Options
      *     @param {string} [options.nodeId] - Parent node id to reset all child data
      *     @param {boolean} [options.useAjax] - State of using Ajax
-     * @returns {?Array.<string>} Added node ids
+     * @returns {Array.<string>|undefined} Added node ids
      * @example
      * tree.resetAllData([
      *  {text: 'hello', children: [
@@ -1316,7 +1318,7 @@ var Tree = defineClass(
      *     @param {boolean} [options.useAjax] - State of using Ajax
      * @example
      * tree.removeAllChildren(nodeId); // Redraws the node
-     * tree.removeAllChildren(nodId, true); // Doesn't redraw the node
+     * tree.removeAllChildren(nodId, {isSilent: true}); // Doesn't redraw the node
      */
     removeAllChildren: function(nodeId, options) {
       var treeAjax = this.enabledFeatures.Ajax;
@@ -1369,7 +1371,7 @@ var Tree = defineClass(
      *     @param {boolean} [options.useAjax] - State of using Ajax
      * @example
      * tree.remove(myNodeId); // remove node with redrawing
-     * tree.remove(myNodeId, true); // remove node without redrawing
+     * tree.remove(myNodeId, {isSilent: true}); // remove node without redrawing
      */
     remove: function(nodeId, options) {
       var treeAjax = this.enabledFeatures.Ajax;
@@ -1413,7 +1415,7 @@ var Tree = defineClass(
      *     @param {boolean} [options.useAjax] - State of using Ajax
      * @example
      * tree.move(myNodeId, newParentId); // mode node with redrawing
-     * tree.move(myNodeId, newParentId, true); // move node without redrawing
+     * tree.move(myNodeId, newParentId, {isSilent: true}); // move node without redrawing
      */
     move: function(nodeId, newParentId, index, options) {
       var treeAjax = this.enabledFeatures.Ajax;
@@ -1655,14 +1657,13 @@ var Tree = defineClass(
      *              method: 'POST',
      *              params: function(evt) {
      *                  return {
-     *                      paramA: evt.a,
-     *                      paramB: evt.b
+     *                      paramA: evt.nodeId,
      *                  };
      *              }
      *          },
      *          removeAllChildren: {
      *              url: function(evt) {
-     *                  return 'api/remove_all/' + evt.nodeId,
+     *                  return 'api/remove_all/' + evt.parentId,
      *              },
      *              contentType: 'application/json',
      *              method: 'POST'

--- a/src/js/treeModel.js
+++ b/src/js/treeModel.js
@@ -348,7 +348,7 @@ var TreeModel = defineClass(
      * Move a node to new parent's child
      * @param {string} nodeId - Node id
      * @param {string} newParentId - New parent id
-     * @param {number} [index] - Start index number for inserting
+     * @param {number} [index] - Start index number for inserting (default 0)
      * @param {boolean} [isSilent] - If true, it doesn't trigger the 'update' event
      */
     /* eslint-disable complexity*/
@@ -381,7 +381,7 @@ var TreeModel = defineClass(
      * @param {string} nodeId - Node id
      * @param {string} newParentId - New parent id
      * @param {string} originalParentId - Original parent id
-     * @param {number} index - Moving index (When child node is moved on parent node, the value is -1)
+     * @param {number} [index] - Moving index (When child node is moved on parent node, the value is -1) (default 0)
      * @private
      */
     _changeOrderOfIds: function(nodeId, newParentId, originalParentId, index) {

--- a/src/js/treeModel.js
+++ b/src/js/treeModel.js
@@ -182,7 +182,7 @@ var TreeModel = defineClass(
     /**
      * Find node
      * @param {string} id - A node id to find
-     * @returns {?TreeNode} Node
+     * @returns {TreeNode|undefined} Node
      */
     getNode: function(id) {
       return this.treeHash[id];

--- a/src/js/treeNode.js
+++ b/src/js/treeNode.js
@@ -272,7 +272,7 @@ var TreeNode = defineClass(
     /**
      * Insert child id
      * @param {string} id - Child node id
-     * @param {number} index - Index number of insert position
+     * @param {number} [index] - Index number of insert position (default 0)
      */
     insertChildId: function(id, index) {
       var childIds = this._childIds;
@@ -285,7 +285,7 @@ var TreeNode = defineClass(
     /**
      * Move child id
      * @param {string} id - Child node id
-     * @param {number} index - Index number of insert position
+     * @param {number} [index] - Index number of insert position (default 0)
      */
     moveChildId: function(id, index) {
       var childIds = this._childIds;


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

I found and fixed several incorrect JSDoc comments, such as:

- Incorrect return types (e.g. returns `null` instead of `undefined`, or vice versa)
- Function parameters that no longer exist
- Function parameters whose shape has changed
- Incorrect code in `@example`

I also fixed `Tree#isLeaf()` so that it always returns a `boolean`.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
